### PR TITLE
Pseduo Error Handling

### DIFF
--- a/src/dynamic/dynamic.cpp
+++ b/src/dynamic/dynamic.cpp
@@ -1,13 +1,5 @@
-#include <iostream>
 #include "../syscore/syscore.h"
 
-void dynamic_loop()
-{
-   SYSLOG_INFO("INFO" << std::endl);
-   SYSLOG_WARN("WARN"<< std::endl);
-   SYSLOG_ERROR("ERROR"<< std::endl);
-   SYSLOG_DEBUG("DEBUG"<< std::endl);
-   SYSLOG_SUCCESS("SUCCESS"<< std::endl);
-   Sleep(1000);
-}
+#include <iostream>
 
+void dynamic_loop( ) {}

--- a/src/ko_client/kc_memutils.h
+++ b/src/ko_client/kc_memutils.h
@@ -1,7 +1,7 @@
 #ifndef KC_MEMUTILS_H
 #define KC_MEMUTILS_H
-#include <windows.h>
 #include <stdint.h>
+#include <windows.h>
 
 /**
  * @brief kc_memutils.h
@@ -11,9 +11,9 @@
  * 
  */
 
-#define GB_TO_BYTES(gb) ((uint64_t)(1073741824 * gb))
-#define MB_TO_BYTES(mb) ((uint64_t)(1048576 * mb))
-#define KB_TO_BYTES(kb) ((uint64_t)(1024 * kb))
+#define GB_TO_BYTES(gb) ((uint64_t) (1073741824 * gb))
+#define MB_TO_BYTES(mb) ((uint64_t) (1048576 * mb))
+#define KB_TO_BYTES(kb) ((uint64_t) (1024 * kb))
 
 #define BYTES_TO_GB(bytes) (bytes / 1073741824.0)
 #define BYTES_TO_MB(bytes) (bytes / 1048576.0)
@@ -39,15 +39,15 @@
  * @return void* returns a pointer to the beginning of the pattern found in the haystack
  * 
  */
-void* memmem(const void *haystack, size_t hs_len, const void *needle, size_t ne_len);
+void* memmem(const void* haystack, size_t hs_len, const void* needle, size_t ne_len);
 
 // This type points to an address in the address space of the other process.
 // The data pointed by the OTHER_PROCESS_PTR is meant to be read using ReadProcessMemory function.
-typedef uint8_t *OTHER_PROCESS_PTR; 
+typedef uint8_t* OTHER_PROCESS_PTR;
 
 // This type points to an address in the address space of our own process.
 // The data pointed by the HOST_PROCESS_PTR can be accessed as usual using the asterisk (*) operator.
-typedef uint8_t *HOST_PROCESS_PTR;  
+typedef uint8_t* HOST_PROCESS_PTR;
 
 /**
  * @brief  PROCESS_MEMORY
@@ -64,51 +64,49 @@ typedef uint8_t *HOST_PROCESS_PTR;
  */
 class PROCESS_MEMORY
 {
-    // DATA:
-private:
-    HOST_PROCESS_PTR mapped_memory = nullptr; // pointer to a region in our heap that will hold a copy of the other process' memory.
-    OTHER_PROCESS_PTR map_base_address = nullptr; // the address in the address space of the other process at which we started copying.
-    SIZE_T map_num_bytes = 0; // number of bytes to copy from the other process
+     // DATA:
+                                                                           private:
+     HOST_PROCESS_PTR  mapped_memory    = nullptr;     // pointer to a region in our heap that will hold a copy of the other process' memory.
+     OTHER_PROCESS_PTR map_base_address = nullptr;     // the address in the address space of the other process at which we started copying.
+     SIZE_T            map_num_bytes    = 0;           // number of bytes to copy from the other process
 
-    // METHODS:
-    /**
+     // METHODS:
+     /**
      * @brief Construct PROCESS_MEMORY, copies num_bytes from the base_address into heap.
      * 
      * @param process_handle handle to the process
      * @param base_address base address in the address space of the external process to start the map from
      * @param num_bytes number of bytes to copy
      */
-public:
-    explicit PROCESS_MEMORY(HANDLE process_handle, OTHER_PROCESS_PTR base_address, SIZE_T num_bytes);
-    /**
+                                                                           public:
+     explicit PROCESS_MEMORY(HANDLE process_handle, OTHER_PROCESS_PTR base_address, SIZE_T num_bytes);
+     /**
      * @brief Destroy PROCESS_MEMORY. Deallocates all the copied memory.
      * 
      */
-    ~PROCESS_MEMORY();
+     ~PROCESS_MEMORY( );
 
-    // No copy constructor or copy assignment operator.
-    PROCESS_MEMORY(const PROCESS_MEMORY&) = delete;
-    PROCESS_MEMORY& operator=(const PROCESS_MEMORY&) = delete;
+     // No copy constructor or copy assignment operator.
+     PROCESS_MEMORY(const PROCESS_MEMORY&)            = delete;
+     PROCESS_MEMORY& operator=(const PROCESS_MEMORY&) = delete;
 
-
-    /**
+     /**
      * @brief Translates a pointer within the internal mapped_memory to a pointer in the address space of the external process.
      * 
      * @param ptr A pointer pointing somewhere within the internal mapped_memory byte array.
      * @return OTHER_PROCESS_PTR A pointer to the same address, expressed in the address space of the external process.
      */
-    inline OTHER_PROCESS_PTR host_ptr_to_other(HOST_PROCESS_PTR ptr) { return (OTHER_PROCESS_PTR)((uint8_t *)map_base_address + ((uint64_t)ptr - (uint64_t)mapped_memory)); }
+     inline OTHER_PROCESS_PTR host_ptr_to_other(HOST_PROCESS_PTR ptr) { return (OTHER_PROCESS_PTR) ((uint8_t*) map_base_address + ((uint64_t) ptr - (uint64_t) mapped_memory)); }
 
-
-    /**
+     /**
      * @brief Translates a pointer within the address space of the external process to an internal pointer to the mapped_memory.
      * 
      * @param ptr A pointer pointing to an address in the address space of the external process.
      * @return HOST_PROCESS_PTR A pointer to the same address, expressed in the the internal memory map.
      */
-    inline HOST_PROCESS_PTR other_ptr_to_host(OTHER_PROCESS_PTR ptr) { return (HOST_PROCESS_PTR)&mapped_memory[(uint64_t)ptr - (uint64_t)map_base_address]; }
+     inline HOST_PROCESS_PTR other_ptr_to_host(OTHER_PROCESS_PTR ptr) { return (HOST_PROCESS_PTR) &mapped_memory[(uint64_t) ptr - (uint64_t) map_base_address]; }
 
-    /**
+     /**
      * @brief Finds a pattern of bytes in the mapped memory and returns its original address in the external process memory.
      * 
      * 
@@ -117,116 +115,125 @@ public:
      * @param search_start_addr_in_process_space  (Optional) Used for starting the search from an offset.
      * @return OTHER_PROCESS_PTR A pointer to the first match of the pattern, in the address space of the external process.
      */
-    OTHER_PROCESS_PTR find_pattern_in_memory(BYTE *pattern_ptr, size_t pattern_size, OTHER_PROCESS_PTR search_start_addr_in_process_space = nullptr);
+     OTHER_PROCESS_PTR find_pattern_in_memory(BYTE* pattern_ptr, size_t pattern_size, OTHER_PROCESS_PTR search_start_addr_in_process_space = nullptr);
 };
 
 #endif
 
 #ifdef KC_MEMUTILS_IMPLEMENTATION
-#pragma once 
-    void* memmem(const void *haystack, size_t hs_len, const void *needle, size_t ne_len)
-    {
-    const char* hs = (char*) haystack;
-    const char* ne = (char*) needle;
+#pragma once
+void* memmem(const void* haystack, size_t hs_len, const void* needle, size_t ne_len)
+{
+     const char* hs = (char*) haystack;
+     const char* ne = (char*) needle;
 
-    if (ne_len == 0)
-        return (void *)hs;
-    int i;
-    int c = ne[0];
-    const char *end = hs + hs_len - ne_len;
+     if(ne_len == 0)
+          return (void*) hs;
+     int         i;
+     int         c   = ne[0];
+     const char* end = hs + hs_len - ne_len;
 
-    for ( ; hs <= end; hs++)
-    {
-        if (hs[0] != c)
-        continue;
-        for (i = ne_len - 1; i != 0; i--)
-        if (hs[i] != ne[i])
-        break;
-        if (i == 0)
-        return (void *)hs;
-    }
+     for(; hs <= end; hs++)
+     {
+          if(hs[0] != c)
+               continue;
+          for(i = ne_len - 1; i != 0; i--)
+               if(hs[i] != ne[i])
+                    break;
+          if(i == 0)
+               return (void*) hs;
+     }
 
-    return NULL;
-    }
+     return NULL;
+}
 
-    PROCESS_MEMORY::PROCESS_MEMORY(HANDLE process_handle, OTHER_PROCESS_PTR base_address, SIZE_T num_bytes)
-    {
-        this->map_num_bytes = num_bytes;
-        //assert(process_handle != nullptr); //TODO: SHA, whoever uses this constructor must open the process themselves.
+PROCESS_MEMORY::PROCESS_MEMORY(HANDLE process_handle, OTHER_PROCESS_PTR base_address, SIZE_T num_bytes)
+{
+     this->map_num_bytes = num_bytes;
+     //assert(process_handle != nullptr); //TODO: SHA, whoever uses this constructor must open the process themselves.
 
-        // Remark: This is also guaranteed to initialize the whole memory to 0.
-        // memset(mapped_memory, 0, bytes_to_map) is implied.
-        this->mapped_memory = (HOST_PROCESS_PTR) VirtualAlloc(NULL, map_num_bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+     // Remark: This is also guaranteed to initialize the whole memory to 0.
+     // memset(mapped_memory, 0, bytes_to_map) is implied.
+     this->mapped_memory = (HOST_PROCESS_PTR) VirtualAlloc(NULL, map_num_bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 
-        MEMORY_BASIC_INFORMATION first_region_info;
-        auto accessed_memory_region = VirtualQueryEx(process_handle, base_address, &first_region_info, sizeof(first_region_info));
-        this->map_base_address = (OTHER_PROCESS_PTR)first_region_info.BaseAddress;
+     MEMORY_BASIC_INFORMATION first_region_info;
+     auto                     accessed_memory_region = VirtualQueryEx(process_handle, base_address, &first_region_info, sizeof(first_region_info));
+     this->map_base_address                          = (OTHER_PROCESS_PTR) first_region_info.BaseAddress;
 
-        // Iterate over the memory regions
-        uint64_t current_byte_offset = 0;
-        OTHER_PROCESS_PTR address = base_address;
+     // Iterate over the memory regions
+     uint64_t          current_byte_offset = 0;
+     OTHER_PROCESS_PTR address             = base_address;
 
-        // The idea is to simply iterate over the memory regions, copy them using ReadProcessMemory if we have access to them.
-        // And skip them if they are guarded.
-        bool reached_the_end = false;
-        while (!reached_the_end) {
-            MEMORY_BASIC_INFORMATION region_info;
-            auto accessed_memory_region = VirtualQueryEx(process_handle, address, &region_info, sizeof(region_info));
-            if (!accessed_memory_region) {break;} //TODO: SHA, throw exception or assert.
+     // The idea is to simply iterate over the memory regions, copy them using ReadProcessMemory if we have access to them.
+     // And skip them if they are guarded.
+     bool reached_the_end = false;
+     while(!reached_the_end)
+     {
+          MEMORY_BASIC_INFORMATION region_info;
+          auto                     accessed_memory_region = VirtualQueryEx(process_handle, address, &region_info, sizeof(region_info));
+          if(!accessed_memory_region)
+          {
+               break;
+          }     //TODO: SHA, throw exception or assert.
 
-            uint64_t bytes_to_read_from_this_segment;
-            if (current_byte_offset + region_info.RegionSize >= map_num_bytes)
-            {
-                reached_the_end = true;
-                bytes_to_read_from_this_segment = map_num_bytes - current_byte_offset; 
-            }
-            else
-            {
-                bytes_to_read_from_this_segment = region_info.RegionSize;
-            }
+          uint64_t bytes_to_read_from_this_segment;
+          if(current_byte_offset + region_info.RegionSize >= map_num_bytes)
+          {
+               reached_the_end                 = true;
+               bytes_to_read_from_this_segment = map_num_bytes - current_byte_offset;
+          }
+          else
+          {
+               bytes_to_read_from_this_segment = region_info.RegionSize;
+          }
 
-            const bool can_read_region = region_info.Protect != PAGE_NOACCESS &&
-                                   region_info.Protect != PAGE_EXECUTE_WRITECOPY &&
-                                   region_info.Protect != PAGE_EXECUTE &&
-                                   region_info.Protect != PAGE_WRITECOPY &&
-                                   region_info.Protect != PAGE_TARGETS_INVALID;
+          const bool can_read_region = region_info.Protect != PAGE_NOACCESS && region_info.Protect != PAGE_EXECUTE_WRITECOPY && region_info.Protect != PAGE_EXECUTE &&
+                                       region_info.Protect != PAGE_WRITECOPY && region_info.Protect != PAGE_TARGETS_INVALID;
 
-            if(can_read_region)
-            {
-                bool succeed = ReadProcessMemory(process_handle,region_info.BaseAddress, &mapped_memory[current_byte_offset], bytes_to_read_from_this_segment, NULL);
-            }
+          if(can_read_region)
+          {
+               bool succeed = ReadProcessMemory(process_handle, region_info.BaseAddress, &mapped_memory[current_byte_offset], bytes_to_read_from_this_segment, NULL);
+          }
 
-            current_byte_offset += bytes_to_read_from_this_segment;
-            address = (OTHER_PROCESS_PTR) region_info.BaseAddress + region_info.RegionSize;
-        }
-    }
-    PROCESS_MEMORY::~PROCESS_MEMORY()
-    {
-        if(this->mapped_memory) VirtualFree(this->mapped_memory, 0, MEM_RELEASE);
-    }
+          current_byte_offset += bytes_to_read_from_this_segment;
+          address = (OTHER_PROCESS_PTR) region_info.BaseAddress + region_info.RegionSize;
+     }
+}
+PROCESS_MEMORY::~PROCESS_MEMORY( )
+{
+     if(this->mapped_memory)
+          VirtualFree(this->mapped_memory, 0, MEM_RELEASE);
+}
 
-    OTHER_PROCESS_PTR PROCESS_MEMORY::find_pattern_in_memory(BYTE* pattern_ptr, size_t pattern_size, OTHER_PROCESS_PTR search_start_addr_in_process_space)
-    {
-        // TODO: Do something if this function fails to find. 
-        HOST_PROCESS_PTR search_start_address_in_map;
-        SIZE_T search_size;
+OTHER_PROCESS_PTR PROCESS_MEMORY::find_pattern_in_memory(BYTE* pattern_ptr, size_t pattern_size, OTHER_PROCESS_PTR search_start_addr_in_process_space)
+{
+     // TODO: Do something if this function fails to find.
+     HOST_PROCESS_PTR search_start_address_in_map;
+     SIZE_T           search_size;
 
-        if(search_start_addr_in_process_space)
-        {
-            uint64_t start_offset = (uint64_t) search_start_addr_in_process_space - (uint64_t) this->map_base_address;
-            search_start_address_in_map = &(this->mapped_memory[start_offset]);
-            search_size = map_num_bytes - start_offset;
-        }
-        else
-        {
-            search_start_address_in_map = this->mapped_memory;
-            search_size = map_num_bytes;
-        }
+     if(search_start_addr_in_process_space)
+     {
+          uint64_t start_offset       = (uint64_t) search_start_addr_in_process_space - (uint64_t) this->map_base_address;
+          search_start_address_in_map = &(this->mapped_memory[start_offset]);
+          search_size                 = map_num_bytes - start_offset;
+     }
+     else
+     {
+          search_start_address_in_map = this->mapped_memory;
+          search_size                 = map_num_bytes;
+     }
 
-        const HOST_PROCESS_PTR result = (HOST_PROCESS_PTR) memmem((void*) search_start_address_in_map, search_size, pattern_ptr, pattern_size);
+     const HOST_PROCESS_PTR result = (HOST_PROCESS_PTR) memmem((void*) search_start_address_in_map, search_size, pattern_ptr, pattern_size);
 
-        uint64_t offset = (uint64_t) result -  (uint64_t) this->mapped_memory;
-        return host_ptr_to_other(result);
-    }
+     if(result)
+     {
+          uint64_t offset = (uint64_t) result - (uint64_t) this->mapped_memory;
+          return host_ptr_to_other(result);
+     }
+     else
+     {
+          return nullptr;
+     }
+}
 
 #endif

--- a/src/ko_client/ko_client.h
+++ b/src/ko_client/ko_client.h
@@ -87,20 +87,13 @@ class KO_CLIENT
    * @return KO_MEM_ADR A pointer to the first match to the pattern, expressed
    * in the address space of KnighOnline.
    */
-     KO_MEM_ADR find_skill_cooldown_ptr_generic(PROCESS_MEMORY&   ko_memory_ref,
-                                                KO_MEMORY_CONFIG& conf,
-                                                KO_MEM_BYTE*      skill_byte_pattern,
-                                                size_t            byte_pattern_size);
+     KO_MEM_ADR find_skill_cooldown_ptr_generic(PROCESS_MEMORY& ko_memory_ref, KO_MEMORY_CONFIG& conf, KO_MEM_BYTE* skill_byte_pattern, size_t byte_pattern_size);
 
 /**
  * @brief A utility macro to call find_skill_cooldown_ptr_generic for a skill
  * name.
  */
-#define find_skill_cooldown_ptr(ko_memory_ref, conf, skill_name)                                             \
-     find_skill_cooldown_ptr_generic(ko_memory_ref,                                                          \
-                                     conf,                                                                   \
-                                     conf.skill_name##_byte_pattern,                                         \
-                                     sizeof(conf.skill_name##_byte_pattern));
+#define find_skill_cooldown_ptr(ko_memory_ref, conf, skill_name) find_skill_cooldown_ptr_generic(ko_memory_ref, conf, conf.skill_name##_byte_pattern, sizeof(conf.skill_name##_byte_pattern));
 
      /**
    * @brief  Finds the patterns for the player health and mana information in
@@ -143,80 +136,91 @@ class KO_CLIENT
     * successful skill activation, allowing the system to proceed to the next skill
     * confidently.
     */
-#define DEFINE_SEND_SKILL_UNTIL_IN_COOLDOWN_FUNC(skill)                                                               \
-     void send_##skill##_until_in_cooldown( ) const noexcept                                                          \
-     {                                                                                                                \
-          const float epsilon                  = 1e-6; /* Tolerance for floating-point number comparison */           \
-          const int   previous_cooldowns_count = 3;    /* Number of previous cooldowns to consider */                 \
-          const int   input_overwhelm_protection_ms = 50;   /* Protect against input lag */                           \
-          const int   max_duration_ms               = 3000; /* Timeout in ms */                                       \
-                                                                                                                      \
-          float current_cooldown = get_##skill##_cooldown( );                                                         \
-          float previous_cooldown;                                                                                    \
-          int   previous_decreasing_cooldown_count = 0; /* Track previous cooldowns */                                \
-          auto  start_time                         = std::chrono::high_resolution_clock::now( );                      \
-                                                                                                                      \
-          if(current_cooldown > epsilon) { return; } /* If skill is in cooldown, return */                            \
-                                                                                                                      \
-          while(true)                                                                                                 \
-          {                                                                                                           \
-               send_multiple_keys(skill##_page, skill##_key); /* Attempt to activate the skill */                     \
-               previous_cooldown = current_cooldown;                                                                  \
-               current_cooldown  = get_##skill##_cooldown( ); /* Get current cooldown */                              \
-                                                                                                                      \
-               Sleep(input_overwhelm_protection_ms);                                                                  \
-                                                                                                                      \
-               const bool is_previous_cooldown_bigger_than_current_cooldown =                                         \
-                   previous_cooldown - current_cooldown > epsilon;                                                    \
-                                                                                                                      \
-               if(is_previous_cooldown_bigger_than_current_cooldown) /* Skill is active and cooldown is decreasing */ \
-               {                                                                                                      \
-                    previous_decreasing_cooldown_count++; /* Track decreasing cooldown count */                       \
-               }                                                                                                      \
-               else                                                                                                   \
-               {                                                                                                      \
-                    previous_decreasing_cooldown_count = 0; /* If the trail fails, start again */                     \
-                    continue;                                                                                         \
-               }                                                                                                      \
-                                                                                                                      \
-               bool is_cooldown_consistently_decreasing =                                                             \
-                   previous_decreasing_cooldown_count == previous_cooldowns_count;                                    \
-                                                                                                                      \
-               if(is_cooldown_consistently_decreasing) /* X amount of previous cooldowns is decreasing */             \
-               {                                                                                                      \
-                    send_raw_key(VK_R);                                                                               \
-                    return;                                                                                           \
-               }                                                                                                      \
-                                                                                                                      \
-               auto elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(                             \
-                   std::chrono::high_resolution_clock::now( ) - start_time);                                          \
-                                                                                                                      \
-               if(elapsed_time.count( ) >= max_duration_ms) { break; } /* Timeout */                                  \
-          }                                                                                                           \
+#define DEFINE_SEND_SKILL_UNTIL_IN_COOLDOWN_FUNC(skill)                                                                                                                                                \
+     bool send_##skill##_until_in_cooldown( ) const noexcept                                                                                                                                           \
+     {                                                                                                                                                                                                 \
+          const float epsilon                       = 1e-6; /* Tolerance for floating-point number comparison */                                                                                       \
+          const int   previous_cooldowns_count      = 3;    /* Number of previous cooldowns to consider */                                                                                             \
+          const int   input_overwhelm_protection_ms = 50;   /* Protect against input lag */                                                                                                            \
+          const int   max_duration_ms               = 3000; /* Timeout in ms */                                                                                                                        \
+                                                                                                                                                                                                       \
+          float current_cooldown = get_##skill##_cooldown( );                                                                                                                                          \
+          float previous_cooldown;                                                                                                                                                                     \
+          int   previous_decreasing_cooldown_count = 0; /* Track previous cooldowns */                                                                                                                 \
+          auto  start_time                         = std::chrono::high_resolution_clock::now( );                                                                                                       \
+                                                                                                                                                                                                       \
+          if(current_cooldown > epsilon)                                                                                                                                                               \
+          {                                                                                                                                                                                            \
+               return false;                                                                                                                                                                           \
+          } /* If skill is in cooldown, return */                                                                                                                                                      \
+          while(true)                                                                                                                                                                                  \
+          {                                                                                                                                                                                            \
+               send_multiple_keys(skill##_page, skill##_key); /* Attempt to activate the skill */                                                                                                      \
+               previous_cooldown = current_cooldown;                                                                                                                                                   \
+               current_cooldown  = get_##skill##_cooldown( ); /* Get current cooldown */                                                                                                               \
+                                                                                                                                                                                                       \
+               Sleep(input_overwhelm_protection_ms);                                                                                                                                                   \
+                                                                                                                                                                                                       \
+               const bool is_previous_cooldown_bigger_than_current_cooldown = previous_cooldown - current_cooldown > epsilon;                                                                          \
+                                                                                                                                                                                                       \
+               if(is_previous_cooldown_bigger_than_current_cooldown) /* Skill is active and cooldown is decreasing */                                                                                  \
+               {                                                                                                                                                                                       \
+                    previous_decreasing_cooldown_count++; /* Track decreasing cooldown count */                                                                                                        \
+               }                                                                                                                                                                                       \
+               else                                                                                                                                                                                    \
+               {                                                                                                                                                                                       \
+                    previous_decreasing_cooldown_count = 0; /* If the trail fails, start again */                                                                                                      \
+                    continue;                                                                                                                                                                          \
+               }                                                                                                                                                                                       \
+                                                                                                                                                                                                       \
+               bool is_cooldown_consistently_decreasing = previous_decreasing_cooldown_count == previous_cooldowns_count;                                                                              \
+                                                                                                                                                                                                       \
+               if(is_cooldown_consistently_decreasing) /* X amount of previous cooldowns is decreasing */                                                                                              \
+               {                                                                                                                                                                                       \
+                    send_raw_key(VK_R);                                                                                                                                                                \
+                    return true;                                                                                                                                                                       \
+               }                                                                                                                                                                                       \
+                                                                                                                                                                                                       \
+               auto elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now( ) - start_time);                                                     \
+                                                                                                                                                                                                       \
+               if(elapsed_time.count( ) >= max_duration_ms)                                                                                                                                            \
+               {                                                                                                                                                                                       \
+                    SYSLOG_WARN("Failed to send " << #skill << ", timed out."); /* Log the timeout status */                                                                                           \
+                    return false;                                                                                                                                                                      \
+               } /* Timeout */                                                                                                                                                                         \
+          }                                                                                                                                                                                            \
      }
 
 /**
  * @brief A utility macro to define getter functions that read addresses from
  * the KO memory and returns them as float.
  */
-#define DEFINE_FLOAT_GETTER_FUNC(function_name, variable_name)                                               \
-     [[nodiscard]] inline float function_name( ) const noexcept                                              \
-     {                                                                                                       \
-          float f;                                                                                           \
-          ReadProcessMemory(process_handle, variable_name, &f, sizeof(f), NULL);                             \
-          return f;                                                                                          \
+#define DEFINE_FLOAT_GETTER_FUNC(function_name, variable_name)                                                                                                                                         \
+     [[nodiscard]] inline float function_name( ) const noexcept                                                                                                                                        \
+     {                                                                                                                                                                                                 \
+          float f;                                                                                                                                                                                     \
+          if(!ReadProcessMemory(process_handle, variable_name, &f, sizeof(f), NULL))                                                                                                                   \
+          {                                                                                                                                                                                            \
+               SYSLOG_ERROR("Failed to read memory for " #variable_name ". Returning 0.0.");                                                                                                           \
+               return 0.0f;                                                                                                                                                                            \
+          }                                                                                                                                                                                            \
+          return f;                                                                                                                                                                                    \
      }
 
 /**
  * @brief A utility macro to define getter functions that read addresses from
  * the KO memory and returns them as uint32.
  */
-#define DEFINE_UINT32_GETTER_FUNC(function_name, variable_name)                                              \
-     [[nodiscard]] inline uint32_t function_name( ) const noexcept                                           \
-     {                                                                                                       \
-          uint32_t i;                                                                                        \
-          ReadProcessMemory(process_handle, variable_name, &i, sizeof(i), NULL);                             \
-          return i;                                                                                          \
+#define DEFINE_UINT32_GETTER_FUNC(function_name, variable_name)                                                                                                                                        \
+     [[nodiscard]] inline uint32_t function_name( ) const noexcept                                                                                                                                     \
+     {                                                                                                                                                                                                 \
+          uint32_t i;                                                                                                                                                                                  \
+          if(!ReadProcessMemory(process_handle, variable_name, &i, sizeof(i), NULL))                                                                                                                   \
+          {                                                                                                                                                                                            \
+               SYSLOG_ERROR("Failed to read memory for " #variable_name ". Returning 0.0");                                                                                                            \
+               return 0;                                                                                                                                                                               \
+          }                                                                                                                                                                                            \
+          return i;                                                                                                                                                                                    \
      }
 
 /**
@@ -233,10 +237,9 @@ class KO_CLIENT
  * and the sender uses the getter to determine hit reports (COOLDOWN or READY)
  * based on the current cooldown status.
  */
-#define DEFINE_SKILL_FUNCTIONS(skill)                                                                        \
-     DEFINE_FLOAT_GETTER_FUNC(get_##skill##_cooldown,                                                        \
-                              skill##_cooldown_ptr); /*ie. defines get_spike_cooldown*/                      \
-     DEFINE_SEND_SKILL_UNTIL_IN_COOLDOWN_FUNC(skill) /*ie. defines send_spike_until_in_cooldown*/
+#define DEFINE_SKILL_FUNCTIONS(skill)                                                                                                                                                                  \
+     DEFINE_FLOAT_GETTER_FUNC(get_##skill##_cooldown, skill##_cooldown_ptr); /*ie. defines get_spike_cooldown*/                                                                                        \
+     DEFINE_SEND_SKILL_UNTIL_IN_COOLDOWN_FUNC(skill)                         /*ie. defines send_spike_until_in_cooldown*/
 
                                                                            public:
      /**
@@ -281,6 +284,7 @@ class KO_CLIENT
 #endif
 
 #ifdef KO_CLIENT_IMPLEMENTATION
+
 #pragma once
 
 #define KC_MEMUTILS_IMPLEMENTATION 1
@@ -288,10 +292,21 @@ class KO_CLIENT
 
 KO_CLIENT::KO_CLIENT( )
 {
+
+     SYSLOG_INFO("SETUP STARTED\n");
+     SYSLOG_INFO("PID\n");
      process_id = get_process_id_by_client_name("KnightOnLine.exe");
 
      // TODO: Add Safety Features
      process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, process_id);
+     if(process_handle == NULL)
+     {
+          SYSLOG_ERROR("Failed to open process.\n");
+     }
+     else
+     {
+          SYSLOG_SUCCESS("Successfully opened process with ID " << process_id << std::endl);
+     }
 
      // Map the process memory to search for patterns in it
      double const ko_address_space_heap_starts_at = 0.2;     // GB (via manual inspection using vmmap)
@@ -302,6 +317,7 @@ KO_CLIENT::KO_CLIENT( )
      PROCESS_MEMORY   ko_memory {process_handle, heap_base_address, bytes_to_map};
      KO_MEMORY_CONFIG ko_memory_config;
 
+     SYSLOG_INFO("POINTERS\n");
      // Assign the pointers
      player_race = find_player_race(ko_memory, ko_memory_config);
 
@@ -314,8 +330,8 @@ KO_CLIENT::KO_CLIENT( )
      stab2_cooldown_ptr  = find_skill_cooldown_ptr(ko_memory, ko_memory_config, stab2);
      stab_cooldown_ptr   = find_skill_cooldown_ptr(ko_memory, ko_memory_config, stab);
      stroke_cooldown_ptr = find_skill_cooldown_ptr(ko_memory, ko_memory_config, stroke);
-
      assign_player_health_and_mana_ptr(ko_memory, ko_memory_config);
+     SYSLOG_INFO("SETUP COMPLETED\n");
 }
 
 KO_CLIENT::~KO_CLIENT( ) { CloseHandle(process_handle); }
@@ -324,7 +340,11 @@ DWORD KO_CLIENT::get_process_id_by_client_name(const char* process_name)
 {
      // TODO: Add Safety Features
      HANDLE snapshot_handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-     if(snapshot_handle == INVALID_HANDLE_VALUE) { return 0; }
+     if(snapshot_handle == INVALID_HANDLE_VALUE)
+     {
+          SYSLOG_ERROR("Failed to acquire Process ID. Snapshot Handle is Invalid.");
+          return 0;
+     }
 
      PROCESSENTRY32 process_entry { };
      process_entry.dwSize = sizeof(PROCESSENTRY32);
@@ -338,65 +358,108 @@ DWORD KO_CLIENT::get_process_id_by_client_name(const char* process_name)
                break;
           }
      }
-
      CloseHandle(snapshot_handle);
+     if(result == 0)
+     {
+          SYSLOG_ERROR("Failed to acquire Process ID. No matching process found." << std::endl);
+     }
+     else
+     {
+          SYSLOG_SUCCESS("Successfully acquired Process ID: " << result << std::endl);
+     }
+
      return result;
 }
 
 PLAYER_RACE KO_CLIENT::find_player_race(PROCESS_MEMORY& ko_memory_ref, KO_MEMORY_CONFIG& conf)
 {
-     KO_MEM_ADR result = ko_memory_ref.find_pattern_in_memory(conf.player_nation_identification_byte_pattern,
-                                                              conf.KO_STRING_LENGTH_IN_BYTES);
+     KO_MEM_ADR result = ko_memory_ref.find_pattern_in_memory(conf.player_nation_identification_byte_pattern, conf.KO_STRING_LENGTH_IN_BYTES);
+
+     if(result == nullptr)
+     {
+          SYSLOG_WARN("Failed to find the pattern. Player Race search failed.\n");
+          assert(1);     // TODO: do something about this.
+          return PLAYER_RACE::KARUS;
+     }
 
      result += conf.player_nation_identification_offset_from_pattern;
 
      KO_MEM_BYTE nation_byte;
-     ReadProcessMemory(process_handle, result, &nation_byte, sizeof(nation_byte), NULL);
+     if(!ReadProcessMemory(process_handle, result, &nation_byte, sizeof(nation_byte), NULL))
+     {
+          SYSLOG_ERROR("Failed to read memory (find_player_race)\n");
+          assert(1);     // TODO: do something about this.
+          return PLAYER_RACE::KARUS;
+     }
 
      switch(nation_byte)
      {
-          case conf.player_nation_human: return PLAYER_RACE::EL_MORAD;
-          case conf.player_nation_karus: return PLAYER_RACE::KARUS;
+          case conf.player_nation_human: SYSLOG_SUCCESS("Successfully acquired the player race as El Morad\n"); return PLAYER_RACE::EL_MORAD;
+
+          case conf.player_nation_karus: SYSLOG_SUCCESS("Successfully acquired the player race as Karus\n"); return PLAYER_RACE::KARUS;
+
           default:
+               SYSLOG_WARN("Failed to identify player nation\n");
                assert(1);     // TODO: do something about this.
                return PLAYER_RACE::KARUS;
      }
 }
 
-KO_MEM_ADR KO_CLIENT::find_skill_cooldown_ptr_generic(PROCESS_MEMORY&   ko_memory_ref,
-                                                      KO_MEMORY_CONFIG& conf,
-                                                      KO_MEM_BYTE*      skill_byte_pattern,
-                                                      size_t            byte_pattern_size)
+KO_MEM_ADR KO_CLIENT::find_skill_cooldown_ptr_generic(PROCESS_MEMORY& ko_memory_ref, KO_MEMORY_CONFIG& conf, KO_MEM_BYTE* skill_byte_pattern, size_t byte_pattern_size)
 {
-     KO_MEM_ADR result = ko_memory_ref.find_pattern_in_memory(skill_byte_pattern, byte_pattern_size);
+     std::string name_of_skill = std::string(reinterpret_cast<char*>(skill_byte_pattern), 40);
+     KO_MEM_ADR  result        = ko_memory_ref.find_pattern_in_memory(skill_byte_pattern, byte_pattern_size);
+
+     if(result == nullptr)
+     {
+          SYSLOG_WARN("Failed to find the pattern. Skill cooldown pointer search failed: (1) " << name_of_skill << std::endl);
+          return nullptr;     // or handle failure as appropriate
+     }
 
      KO_MEM_ADR  nation_byte_adr = result + conf.skill_nation_identification_offset_from_pattern;
      KO_MEM_BYTE nation_byte;
-     ReadProcessMemory(process_handle, nation_byte_adr, &nation_byte, sizeof(nation_byte), NULL);
+
+     if(!ReadProcessMemory(process_handle, nation_byte_adr, &nation_byte, sizeof(nation_byte), NULL))
+     {
+          SYSLOG_ERROR("Failed to read memory (find_skill_cooldown_ptr_generic)\n");
+          return nullptr;     // or handle failure as appropriate
+     }
 
      // If not the first match, then it's the second match.
      if(nation_byte != (KO_MEM_BYTE) player_race)
+     {
           result = ko_memory_ref.find_pattern_in_memory(skill_byte_pattern, byte_pattern_size, result + 1);
 
+          if(result == nullptr)
+          {
+               SYSLOG_WARN("Failed to find the pattern. Skill cooldown pointer search failed: (2) " << name_of_skill << std::endl);
+               return nullptr;
+          }
+     }
+
+     SYSLOG_SUCCESS("Successfully acquired cooldown pointer. Skill: " << name_of_skill << std::endl);
      return result + conf.skill_cooldown_offset_from_pattern;
 }
 
 void KO_CLIENT::assign_player_health_and_mana_ptr(PROCESS_MEMORY& ko_memory_ref, KO_MEMORY_CONFIG& conf)
 {
-     KO_MEM_ADR result = ko_memory_ref.find_pattern_in_memory(conf.mana_hp_anchor_byte_pattern,
-                                                              sizeof(conf.mana_hp_anchor_byte_pattern));
+     KO_MEM_ADR result = ko_memory_ref.find_pattern_in_memory(conf.mana_hp_anchor_byte_pattern, sizeof(conf.mana_hp_anchor_byte_pattern));
+
+     if(result == nullptr)
+     {
+          SYSLOG_WARN("Failed to find anchor pattern. Player health and mana pointer assignment failed.\n");
+          return;     // or handle failure as appropriate
+     }
 
      player_max_hp_ptr = result + conf.max_hp_offset_from_pattern;
      player_cur_hp_ptr = result + conf.current_hp_offset_from_pattern;
 
      player_max_mp_ptr = result + conf.max_mana_offset_from_pattern;
      player_cur_mp_ptr = result + conf.current_mana_offset_from_pattern;
+
+     SYSLOG_SUCCESS("Successfully acquired HP & MP.\n");
 }
 
-inline void KO_CLIENT::print_info( ) const noexcept
-{
-     std::cout << "Knight Online PID: " << process_id << "\nKnight Online Handle:  " << process_handle
-               << std::endl;
-}
+inline void KO_CLIENT::print_info( ) const noexcept { std::cout << "Knight Online PID: " << process_id << "\nKnight Online Handle:  " << process_handle << std::endl; }
 
 #endif

--- a/src/syscore/sc_benchmark.h
+++ b/src/syscore/sc_benchmark.h
@@ -1,6 +1,6 @@
 #ifndef SYSCORE_BENCHMARK_H
 #define SYSCORE_BENCHMARK_H
-#include  "windows.h"
+#include "windows.h"
 /**
  * @class TICTOC
  *
@@ -10,68 +10,76 @@
  */
 class TICTOC
 {
-    private:
-        LARGE_INTEGER freq; // Frequency of the QuerryPerformanceCounter. Fixed at computer boot.
-        LARGE_INTEGER tic_count; // The initial count of the QuerryPerformanceCounter.
-        LARGE_INTEGER toc_count; // The final count of the QuerryPerformanceCounter.
-        double time_difference_ms; // Time difference between the initial and final count.
+                                                                           private:
+     LARGE_INTEGER freq;                   // Frequency of the QuerryPerformanceCounter. Fixed at computer boot.
+     LARGE_INTEGER tic_count;              // The initial count of the QuerryPerformanceCounter.
+     LARGE_INTEGER toc_count;              // The final count of the QuerryPerformanceCounter.
+     double        time_difference_ms;     // Time difference between the initial and final count.
 
-    public:
-        /**
+                                                                           public:
+     /**
          * @brief Construct a new TICTOC timer. Timer doesn't start till the tic method is run.
          */
-        TICTOC();
+     TICTOC( );
 
-        /**
+     /**
          * @brief Start the timer.
          */
-        void tic();
+     void tic( );
 
-        /**
+     /**
          * @brief End the timer.
          */
-        void toc();
+     void toc( );
 
-        /**
+     /**
          * @brief Returns the elapsed time in ms.
          */
-        double elapsed_time_in_ms();
+     double elapsed_time_in_ms( );
 
-
-        /**
+     /**
          * @brief Returns the elapsed time in ns.
          */
-        double elapsed_time_in_ns();
+     double elapsed_time_in_ns( );
 };
 
 #endif
 
 #ifdef SYSCORE_BENCHMARK_IMPLEMENTATION
-    TICTOC::TICTOC()
-    {
-        QueryPerformanceFrequency(&freq);
-    }
+TICTOC::TICTOC( )
+{
+     if(!QueryPerformanceFrequency(&freq))
+     {
+          // Log an error if QueryPerformanceFrequency fails
+          SYSLOG_ERROR("QueryPerformanceFrequency failed.\n");
+          // Handle the error as appropriate
+     }
+}
 
-    void inline TICTOC::tic()
-    {
-        QueryPerformanceCounter(&tic_count);
-    }
+void inline TICTOC::tic( )
+{
+     if(!QueryPerformanceCounter(&tic_count))
+     {
+          // Log an error if QueryPerformanceCounter fails
+          SYSLOG_ERROR("QueryPerformanceCounter (tic) failed.\n");
+          // Handle the error as appropriate
+     }
+}
 
-    void inline TICTOC::toc()
-    {
-        QueryPerformanceCounter(&toc_count);
+void inline TICTOC::toc( )
+{
+     if(!QueryPerformanceCounter(&toc_count))
+     {
+          // Log an error if QueryPerformanceCounter fails
+          SYSLOG_ERROR("QueryPerformanceCounter (toc) failed.\n");
+          // Handle the error as appropriate
+     }
 
-        time_difference_ms = ((double)(toc_count.QuadPart - tic_count.QuadPart) / freq.QuadPart * 1000);
-    }
+     time_difference_ms = ((double) (toc_count.QuadPart - tic_count.QuadPart) / freq.QuadPart * 1000);
+}
 
-    double inline TICTOC::elapsed_time_in_ms()
-    {
-        return time_difference_ms;
-    }
-    double inline TICTOC::elapsed_time_in_ns()
-    {
-        return time_difference_ms * 1000000;
-    }
+double inline TICTOC::elapsed_time_in_ms( ) { return time_difference_ms; }
+
+double inline TICTOC::elapsed_time_in_ns( ) { return time_difference_ms * 1000000; }
 
 #endif
-

--- a/src/syscore/sc_keys.h
+++ b/src/syscore/sc_keys.h
@@ -134,8 +134,18 @@ enum SKILL_HIT_REPORT
 #ifdef SYSCORE_KEYS_IMPLEMENTATION
 bool is_key_pressed(const int& key_code)
 {
-     // Check if the key is pressed by using bitwise AND with the high-order bit
-     return (GetAsyncKeyState(key_code) & 0x8000) != 0;
+     short key_state = GetAsyncKeyState(key_code);
+
+     if(key_state == 0)
+     {
+          // GetAsyncKeyState returns zero if the key is not pressed or an error occurs
+          SYSLOG_ERROR("GetAsyncKeyState failed for key " << key_code << std::endl);
+          // Handle the error as appropriate
+          return false;
+     }
+
+     // Check if the high-order bit is set, indicating the key is pressed
+     return (key_state & 0x8000) != 0;
 }
 
 template<typename... Keys>
@@ -150,6 +160,12 @@ void send_raw_key(const uint16_t& key, const uint8_t& key_press_release_delay_in
 
      //Translating virtual-code to scan code for Knight Online.
      uint16_t scan_code = MapVirtualKey(key, 0);
+
+     if(scan_code == 0)
+     {
+          SYSLOG_ERROR("MapVirtualKey failed for key: " << key << std::endl);
+          // Handle the error as appropriate
+     }
 
      INPUT keyboard;
 
@@ -166,7 +182,7 @@ void send_raw_key(const uint16_t& key, const uint8_t& key_press_release_delay_in
      bool is_send_input_successful = SendInput(1, &keyboard, sizeof(INPUT));
      if(!is_send_input_successful)
      {
-          // SYSLOG_ERROR("Key_down event failed with error code: " << GetLastError() << "\nFailed Key: " << scan_code << "\nFailed Virtual Key: " << key);
+          SYSLOG_ERROR("Key_down event failed with error code: " << GetLastError( ) << "\nFailed Key: " << scan_code << "\nFailed Virtual Key: " << key << std::endl);
           return;
      }
 
@@ -185,7 +201,7 @@ void send_raw_key(const uint16_t& key, const uint8_t& key_press_release_delay_in
      is_send_input_successful = SendInput(1, &keyboard, sizeof(INPUT));
      if(!is_send_input_successful)
      {
-          // SYSLOG_ERROR("Key_up event failed with error code: " << GetLastError() << "\nFailed Scan Code: " << scan_code << "\nFailed Virtual Key: " << key);
+          SYSLOG_ERROR("Key_up event failed with error code: " << GetLastError( ) << "\nFailed Scan Code: " << scan_code << "\nFailed Virtual Key: " << key << std::endl);
           return;
      }
      Sleep(1);

--- a/src/syscore/syscore.cpp
+++ b/src/syscore/syscore.cpp
@@ -1,5 +1,4 @@
 
-
 // SYCORE
 #include "syscore.h"
 
@@ -8,6 +7,7 @@
 
 #define SYSCORE_KEYS_IMPLEMENTATION 1
 #include "sc_keys.h"
+#include "sc_log.h"
 
 // COMPONENTS
 #define KO_CLIENT_IMPLEMENTATION 1
@@ -30,6 +30,8 @@ int main( )
           global::ko_client.send_cut_until_in_cooldown( );
           global::ko_client.send_shock_until_in_cooldown( );
           global::ko_client.send_jab_until_in_cooldown( );
+
+          Sleep(50);
      }
      return 0;
 }

--- a/src/syscore/syscore.h
+++ b/src/syscore/syscore.h
@@ -1,5 +1,5 @@
 #pragma once
-#define LOGGING_LEVEL 0
-#include "sc_log.h"
+#define LOGGING_LEVEL 1
 #include "sc_benchmark.h"
 #include "sc_keys.h"
+#include "sc_log.h"

--- a/tools/cbuild.bat
+++ b/tools/cbuild.bat
@@ -14,7 +14,7 @@ echo ^|                                                       COMPILATION
 echo ^+----------------------------------------------------------------------------------------------------------------------------+
 
 @REM Define DEBUG variable
-set DEBUG=0
+set DEBUG=1
 
 if %DEBUG% EQU 1 (
     echo ^|  Debug:              ^|  Yes                                           


### PR DESCRIPTION
By using sc_log.h, all errors are indicated using SYSLOG. SYSLOG_ERROR for program breaking errors, SYSLOG_WARN for wrong readings, SYSLOG_DEBUG for working logic, SYSLOG_SUCCESS for successfull resource acquiring.

Closes: SW-46